### PR TITLE
feat: add full-width dash to group name pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
+- Add prolonged sound marks to blendshape group name pattern.
 
 ### Changed
 

--- a/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
+++ b/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
@@ -69,6 +69,7 @@ namespace net.nekobako.EditorPatcher.Editor
                 {
                     @"\W",     // Non-word characters
                     @"\p{Pc}", // Connector punctuation
+                    "ー",      // Full-width dash
                 });
             private const int k_RowHeight = 24;
             private const int k_LineHeight = 22;

--- a/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
+++ b/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
@@ -66,6 +66,7 @@ namespace net.nekobako.EditorPatcher.Editor
                 @"\W",     // Non-Word Characters
                 @"\p{Pc}", // Connector Punctuations
                 @"ー",     // Katakana-Hiragana Prolonged Sound Mark
+                @"ｰ",      // Halfwidth Katakana-Hiragana Prolonged Sound Mark
             });
             private static readonly string s_GroupNamePattern = string.Join("|", new[]
             {

--- a/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
+++ b/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
@@ -60,17 +60,19 @@ namespace net.nekobako.EditorPatcher.Editor
         private class BlendShapesDrawer : TreeView
         {
             private const string k_DefaultGroupName = "Default";
-            private static readonly string k_GroupNamePattern = 
-                new Func<string[], string>(patterns =>
-                {
-                    var symbolPattern = string.Join("|", patterns);
-                    return $@"^(?:(?:{symbolPattern}){{3,}})(.*?)(?:(?:{symbolPattern}){{3,}})?$|^(?:(?:{symbolPattern}){{3,}})?(.*?)(?:(?:{symbolPattern}){{3,}})$";
-                })(new[]
-                {
-                    @"\W",     // Non-word characters
-                    @"\p{Pc}", // Connector punctuation
-                    "ー",      // Full-width dash
-                });
+
+            private static readonly string s_GroupNameSymbolPattern = string.Join("|", new[]
+            {
+                @"\W",     // Non-Word Characters
+                @"\p{Pc}", // Connector Punctuations
+                @"ー",     // Katakana-Hiragana Prolonged Sound Mark
+            });
+            private static readonly string s_GroupNamePattern = string.Join("|", new[]
+            {
+                $"^(?:(?:{s_GroupNameSymbolPattern}){{3,}})(.*?)(?:(?:{s_GroupNameSymbolPattern}){{3,}})?$",
+                $"^(?:(?:{s_GroupNameSymbolPattern}){{3,}})?(.*?)(?:(?:{s_GroupNameSymbolPattern}){{3,}})$",
+            });
+
             private const int k_RowHeight = 24;
             private const int k_LineHeight = 22;
 
@@ -267,7 +269,7 @@ namespace net.nekobako.EditorPatcher.Editor
                 for (var i = 0; m_Mesh != null && i < m_Mesh.blendShapeCount; i++)
                 {
                     var shape = new BlendShape(m_Mesh, i);
-                    var match = Regex.Match(shape.Name, k_GroupNamePattern);
+                    var match = Regex.Match(shape.Name, s_GroupNamePattern);
                     if (match.Success)
                     {
                         m_Groups.Add(new BlendShapeGroup(match.Groups.Skip(1).First(x => x.Success).Value));

--- a/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
+++ b/Packages/net.nekobako.editor-patcher/Editor/SkinnedMeshRendererEditorPatcher.cs
@@ -60,7 +60,16 @@ namespace net.nekobako.EditorPatcher.Editor
         private class BlendShapesDrawer : TreeView
         {
             private const string k_DefaultGroupName = "Default";
-            private const string k_GroupNamePattern = @"^(?:(?:\W|\p{Pc}){3,})(.*?)(?:(?:\W|\p{Pc}){3,})?$|^(?:(?:\W|\p{Pc}){3,})?(.*?)(?:(?:\W|\p{Pc}){3,})$";
+            private static readonly string k_GroupNamePattern = 
+                new Func<string[], string>(patterns =>
+                {
+                    var symbolPattern = string.Join("|", patterns);
+                    return $@"^(?:(?:{symbolPattern}){{3,}})(.*?)(?:(?:{symbolPattern}){{3,}})?$|^(?:(?:{symbolPattern}){{3,}})?(.*?)(?:(?:{symbolPattern}){{3,}})$";
+                })(new[]
+                {
+                    @"\W",     // Non-word characters
+                    @"\p{Pc}", // Connector punctuation
+                });
             private const int k_RowHeight = 24;
             private const int k_LineHeight = 22;
 


### PR DESCRIPTION
シェイプキーの区切りに"ー"を使っているFBXへの対応です。
![image](https://github.com/user-attachments/assets/8ea6257e-5c85-480f-aa7a-e1c41d5c8d2a)
今後追加しやすいように少しパターンの定義方法を変えてみました。