### PR TITLE
fix: array length may be applied to the parent prefab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+- Array length may be applied to the parent prefab when fixing prefab override.
 
 ### Security
 


### PR DESCRIPTION
FixPrefabOverrideにて、対応する親のプロパティが見つからない場合に誤って配列長が親のPrefabに適用されてしまうバグの修正です。
デフォルト値と比較を行いRevertするように変更します。